### PR TITLE
Change displayed units based on Unit Display switch

### DIFF
--- a/electron.html
+++ b/electron.html
@@ -168,25 +168,6 @@
 										<div class="group">
 											<div class="ribbon-group">
 												<input type="checkbox" data-role="switch" name="unitSwitch" id="unitSwitch" onclick="changeUnits()" >
-												<script>
-													function changeUnits() {
-														let unitSwitch = document.getElementById("unitSwitch");
-														let unitDisplay = document.getElementById("unitDisplay");
-														let unitAppend = document.getElementsByClassName("append");
-
-														if (unitSwitch.checked) {
-															unitDisplay.textContent = "inch";
-															for (let i = 0; i < unitAppend.length; i++) {
-																unitAppend[i].textContent = "inch";
-															}
-														} else {
-															unitDisplay.textContent = "mm";
-															for (let i = 0; i < unitAppend.length; i++) {
-																unitAppend[i].textContent = "mm";
-															}
-														}
-													}
-												</script>
 												<br>
 												<label for="unitSwitch" class="caption" id="unitDisplay">mm</label>
 											</div>

--- a/electron.html
+++ b/electron.html
@@ -167,7 +167,28 @@
 
 										<div class="group">
 											<div class="ribbon-group">
-												<input type="checkbox" data-role="switch"  id="unitSwitch" >
+												<input type="checkbox" data-role="switch" name="unitSwitch" id="unitSwitch" onclick="changeUnits()" >
+												<script>
+													function changeUnits() {
+														let unitSwitch = document.getElementById("unitSwitch");
+														let unitDisplay = document.getElementById("unitDisplay");
+														let unitAppend = document.getElementsByClassName("append");
+
+														if (unitSwitch.checked) {
+															unitDisplay.textContent = "inch";
+															for (let i = 0; i < unitAppend.length; i++) {
+																unitAppend[i].textContent = "inch";
+															}
+														} else {
+															unitDisplay.textContent = "mm";
+															for (let i = 0; i < unitAppend.length; i++) {
+																unitAppend[i].textContent = "mm";
+															}
+														}
+													}
+												</script>
+												<br>
+												<label for="unitSwitch" class="caption" id="unitDisplay">mm</label>
 											</div>
 											<span class="title">Unit Display</span>
 										</div>

--- a/index.html
+++ b/index.html
@@ -169,25 +169,6 @@
 										<div class="group">
 											<div class="ribbon-group">
 												<input type="checkbox" data-role="switch" name="unitSwitch" id="unitSwitch" onclick="changeUnits()" >
-												<script>
-													function changeUnits() {
-														let unitSwitch = document.getElementById("unitSwitch");
-														let unitDisplay = document.getElementById("unitDisplay");
-														let unitAppend = document.getElementsByClassName("append");
-
-														if (unitSwitch.checked) {
-															unitDisplay.textContent = "inch";
-															for (let i = 0; i < unitAppend.length; i++) {
-																unitAppend[i].textContent = "inch";
-															}
-														} else {
-															unitDisplay.textContent = "mm";
-															for (let i = 0; i < unitAppend.length; i++) {
-																unitAppend[i].textContent = "mm";
-															}
-														}
-													}
-												</script>
 												<br>
 												<label for="unitSwitch" class="caption" id="unitDisplay">mm</label>
 											</div>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,28 @@
 
 										<div class="group">
 											<div class="ribbon-group">
-												<input type="checkbox" data-role="switch"  id="unitSwitch" >
+												<input type="checkbox" data-role="switch" name="unitSwitch" id="unitSwitch" onclick="changeUnits()" >
+												<script>
+													function changeUnits() {
+														let unitSwitch = document.getElementById("unitSwitch");
+														let unitDisplay = document.getElementById("unitDisplay");
+														let unitAppend = document.getElementsByClassName("append");
+
+														if (unitSwitch.checked) {
+															unitDisplay.textContent = "inch";
+															for (let i = 0; i < unitAppend.length; i++) {
+																unitAppend[i].textContent = "inch";
+															}
+														} else {
+															unitDisplay.textContent = "mm";
+															for (let i = 0; i < unitAppend.length; i++) {
+																unitAppend[i].textContent = "mm";
+															}
+														}
+													}
+												</script>
+												<br>
+												<label for="unitSwitch" class="caption" id="unitDisplay">mm</label>
 											</div>
 											<span class="title">Unit Display</span>
 										</div>

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -670,3 +670,21 @@ function resetView(object) {
     viewExtents(object);
   }
 }
+
+function changeUnits() {
+  let unitSwitch = document.getElementById("unitSwitch");
+  let unitDisplay = document.getElementById("unitDisplay");
+  let unitAppend = document.getElementsByClassName("append");
+
+  if (unitSwitch.checked) {
+    unitDisplay.textContent = "inch";
+    for (let i = 0; i < unitAppend.length; i++) {
+      unitAppend[i].textContent = "inch";
+    }
+  } else {
+    unitDisplay.textContent = "mm";
+    for (let i = 0; i < unitAppend.length; i++) {
+      unitAppend[i].textContent = "mm";
+    }
+  }
+}

--- a/lib/metro4/css/metro-all.css
+++ b/lib/metro4/css/metro-all.css
@@ -35430,6 +35430,13 @@ html.metro-touch-device .streamer .stream.focused .stream-icon {
 .ribbon-icon-button [class*=mif-] {
   vertical-align: inherit;
 }
+.ribbon-group input[type=checkbox],
+.ribbon-group .caption {
+  display: block;
+  margin: auto;
+  text-align: center;
+  font-size: 12px;
+}
 .ribbon-tool-button {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
This PR will add the functionality that changes the displayed units ("mm" or "inch") in three different areas:
 - The first is under the switch itself
 - The second is under Project Diameter and Project Length

![image](https://user-images.githubusercontent.com/78237202/148450284-6698c4d8-93bc-4514-98a7-b9b13df2de89.png) ![image](https://user-images.githubusercontent.com/78237202/148450405-fa92915e-fcb7-423b-9ef4-b2530e1e7b19.png)

 - The third is on the Settings modal

![image](https://user-images.githubusercontent.com/78237202/148450707-8a8af3f3-d7dd-42e8-adc9-22bdea7d7281.png)

---
@benb1n @rlwoodjr 
Changes have been tested in Electron and Web-App (VSC Live Server)
 

