### PR TITLE
Change the Sender app's download link

### DIFF
--- a/electron.html
+++ b/electron.html
@@ -392,7 +392,7 @@
 											</nav>
 
 
-											<p class="text-secondary" id="installDriverMessage">Connecting to a machine, requires that you have the Basic CONTROL installed.</p>
+											<p class="text-secondary" id="installDriverMessage">Connecting to a machine, requires that you have the Basic SENDER installed.</p>
 											<p class="text-small" id="installDriverHelp">If you have not installed it yet, you can download it above, or if you have the latest version installed already, please start it.<br> If you still see this message, we are
 												experiencing a problem detecting your driver<br> You can also export
 												GCODE and send it to your machine</p>
@@ -403,7 +403,7 @@
 
 											<button class="image-button success" id="sendGcodeToMyMachine" onclick="sendGcodeToMyMachine()" disabled style="width: 100%">
 												<span class="icon"><span class="fas fa-play"></span></span>
-												<span class="caption">Transfer GCODE to Basic CONTROL</span>
+												<span class="caption">Transfer GCODE to Basic SENDER</span>
 											</button>
 											<p class="text-small" id="detectedVersion"></p>
 											<p class="text-small" id="validDocuments"><i class='fas fa-times fa-fw fg-red'></i>2. No Documents yet</p>
@@ -412,7 +412,7 @@
 											<br>
 											<button class="image-button" id="activateDriver" onclick="activateDriver()" style="width: 100%">
 												<span class="icon"><span class="far fa-window-restore"></span></span>
-												<span class="caption">Show CONTROL Window</span>
+												<span class="caption">Show SENDER Window</span>
 											</button>
 										</div>
 									</div>

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
 											</nav>
 
 
-											<p class="text-secondary" id="installDriverMessage">Connecting to a machine, requires that you have the Basic CONTROL installed.</p>
+											<p class="text-secondary" id="installDriverMessage">Connecting to a machine, requires that you have the Basic SENDER installed.</p>
 											<p class="text-small" id="installDriverHelp">If you have not installed it yet, you can download it above, or if you have the latest version installed already, please start it.<br> If you still see this message, we are
 												experiencing a problem detecting your driver<br> You can also export
 												GCODE and send it to your machine</p>
@@ -406,7 +406,7 @@
 
 											<button class="image-button success" id="sendGcodeToMyMachine" onclick="sendGcodeToMyMachine()" disabled style="width: 100%">
 												<span class="icon"><span class="fas fa-play"></span></span>
-												<span class="caption">Transfer GCODE to Basic CONTROL</span>
+												<span class="caption">Transfer GCODE to Basic SENDER</span>
 											</button>
 											<p class="text-small" id="detectedVersion"></p>
 											<p class="text-small" id="validDocuments"><i class='fas fa-times fa-fw fg-red'></i>2. No Documents yet</p>
@@ -415,7 +415,7 @@
 											<br>
 											<button class="image-button" id="activateDriver" onclick="activateDriver()" style="width: 100%">
 												<span class="icon"><span class="far fa-window-restore"></span></span>
-												<span class="caption">Show CONTROL Window</span>
+												<span class="caption">Show SENDER Window</span>
 											</button>
 										</div>
 									</div>

--- a/js/integration-machine-driver.js
+++ b/js/integration-machine-driver.js
@@ -70,7 +70,7 @@ function hasDriver(version) {
   $("#DriverDetected").show();
   alreadyDetected = true;
   $('#installDriversOnSettingspage').hide();
-  $('#detectedVersion').html("<i class='fas fa-check fa-fw fg-green'></i>1. Detected Basic CONTROL: " + version)
+  $('#detectedVersion').html("<i class='fas fa-check fa-fw fg-green'></i>1. Detected Basic SENDER: " + version)
 }
 
 function noDriver() {
@@ -79,8 +79,8 @@ function noDriver() {
   $("#DriverDetected").hide();
   $("#noDriverDetected").show();
   $('#installDriversOnSettingspage').show();
-  $('#detectedVersion').html("<i class='fas fa-times fa-fw fg-red'></i>1. Not detecting Basic CONTROL")
-  $('#installDriverMessage').html('Connecting to a machine, requires that you have the Basic CONTROL installed.')
+  $('#detectedVersion').html("<i class='fas fa-times fa-fw fg-red'></i>1. Not detecting Basic SENDER")
+  $('#installDriverMessage').html('Connecting to a machine, requires that you have the Basic SENDER installed.')
 }
 
 function oldDriver(version, availVersion) {
@@ -89,8 +89,8 @@ function oldDriver(version, availVersion) {
   $("#DriverDetected").hide();
   $("#noDriverDetected").show();
   $('#installDriversOnSettingspage').show();
-  $('#detectedVersion').html("<i class='fas fa-times fa-fw fg-red'></i>1. You are running an outdated version of the Basic CONTROL v." + version + ". Please update to v" + availVersion)
-  $('#installDriverMessage').html('Connecting to a machine, requires that you have the latest Basic CONTROL installed. <br>You are running version <code>' + version + "</code> - Please update to version <code>" + availVersion + "</code> or newer...")
+  $('#detectedVersion').html("<i class='fas fa-times fa-fw fg-red'></i>1. You are running an outdated version of the Basic SENDER v." + version + ". Please update to v" + availVersion)
+  $('#installDriverMessage').html('Connecting to a machine, requires that you have the latest Basic SENDER installed. <br>You are running version <code>' + version + "</code> - Please update to version <code>" + availVersion + "</code> or newer...")
   $('#installDriverHelp').hide();
 }
 // Loop to check if we can use Machine Integration
@@ -215,7 +215,7 @@ function sendGcodeToMyMachine() {
       contentType: false
     }).done(function(data) {
       // console.log(data);
-      var message = `GCODE Successfully sent to Basic CONTROL! Continue from the Basic CONTROL window`
+      var message = `GCODE Successfully sent to Basic SENDER! Continue from the Basic SENDER window`
       Metro.toast.create(message, null, 4000);
     });
   };

--- a/js/integration-machine-driver.js
+++ b/js/integration-machine-driver.js
@@ -26,7 +26,7 @@ function checkIfDriverIsInstalled() {
         setTimeout(function() {
           // console.log('checking for update')
           // printLog("<span class='fg-green'>Checking for Updates</span>")
-          $.getJSON("https://api.github.com/repos/OpenBuilds/OpenBuilds-CONTROL/releases/latest", {
+          $.getJSON("https://api.github.com/repos/rlwoodjr/Basic-CONTROL/releases/latest", {
             crossDomain: true
           }).done(function(release) {
             var availVersion = release.name.substr(1)
@@ -108,7 +108,7 @@ setInterval(function() {
 }, 1000);
 
 function downloadDrivers(os) {
-  $.getJSON("https://api.github.com/repos/OpenBuilds/OpenBuilds-CONTROL/releases/latest", {
+  $.getJSON("https://api.github.com/repos/rlwoodjr/Basic-CONTROL/releases/latest", {
     crossDomain: true
   }).done(function(release) {
     console.log(release)
@@ -153,7 +153,7 @@ function downloadDrivers(os) {
 }
 
 function getAvailableDriverVersion() {
-  $.getJSON("https://api.github.com/repos/OpenBuilds/OpenBuilds-CONTROL/releases/latest", {
+  $.getJSON("https://api.github.com/repos/rlwoodjr/Basic-CONTROL/releases/latest", {
     crossDomain: true
   }).done(function(release) {
     $('.omdavailversion').html(release.name)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bobscnc-basic-cam",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Basic CAM - Cloud based software for converting DXF, SVG, Bitmap (BMP, JPG, PNG, GIF) and Gerber X274 to GCODE",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
@rlwoodjr @benb1n 

I changed the link for downloading the Sender app through the CAM.  Clicking it now looks like it does nothing but behind the scenes it is returning an error with status code 404 because there isn't a "latest release" for Sender yet.
The version number shown should automatically update when Sender is released.

I also changed CONTROL to SENDER.

And finally I increased the version number in package.json so that the build action is successful.

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/78237202/150018883-dcb06357-02fc-4f43-8b40-816d107085ff.gif)

